### PR TITLE
Changed vertical rhythm when cards are stacked

### DIFF
--- a/src/scss/card.scss
+++ b/src/scss/card.scss
@@ -11,8 +11,8 @@
 	line-height: 18px;
 	border-bottom: 1px solid oColorsGetColorFor(heading-medium, border);
 	background-color: oColorsGetColorFor(panel-body box page, background);
-	margin: 0;
-	padding-top: 20px;
+	margin-top: 10px;
+	margin-bottom: 20px;
 	display: block;
 	overflow: hidden;
 


### PR DESCRIPTION
So that if they appear after a heading they do not appear too far away from it. Otherwise vertical spacing is unchanged
