### PR TITLE
Change 'options' into 'demosDefaults'

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -7,7 +7,7 @@
 	"ci": {
 		"circle": "https://circleci.com/api/v1/project/Financial-Times/o-business-card"
 	},
-	"options": {
+	"demosDefaults": {
 		"sass": "demos/src/demo.scss",
 		"dependencies": ["o-fonts@^1.5.0"]
 	},


### PR DESCRIPTION
Change in origami.json for `options` into `demosDefaults`as `options` is deprecated.